### PR TITLE
use xdg instead of copying files into directorys

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -75,8 +75,7 @@ then
 	echo "Type=Application" >> leagueoflegends.desktop
 	echo "Categories=Application;Game" >> leagueoflegends.desktop
 
-	cp leagueoflegends.desktop "$HOME/.local/share/applications/"
-	update-desktop-database "$HOME/.local/share/applications"
+	xdg-desktop-menu instal --novendor leagueoflegends.desktop
 fi
 
 read -p "Would you like a desktop shortcut? y/n" -n 1 -r
@@ -86,7 +85,7 @@ then
 	echo "*************************************************"
 	echo "Creating League of Legends desktop shortcut."
 	echo "*************************************************"
-	cp leagueoflegends.desktop "$HOME/Desktop/"
+	xdg-desktop-icon instal --novendor leagueoflegends.desktop
 fi
 
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,12 +11,13 @@ rm $HOME/bin/leagueoflegends
 echo "*************************************************"
 echo "Removing $HOME/.local/share/applications/leagueoflegends.desktop"
 echo "*************************************************"
-rm $HOME/.local/share/applications/leagueoflegends.desktop
+xdg-desktop-menu uninstall leagueoflegends.desktop
 
 echo "*************************************************"
 echo "Removing $HOME/Desktop/leagueoflegends.desktop"
 echo "*************************************************"
-rm $HOME/Desktop/leagueoflegends.desktop
+xdg-desktop-icon uninstall leagueoflegends.desktop
+
 
 echo "*************************************************"
 echo "Removing $HOME/.wineprefix/LoL"


### PR DESCRIPTION
Using [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) as the freedesktop specifications suggest will fix issues, when the folders that the leagueoflegends.desktop should be copied into don't exist. 